### PR TITLE
[TASK] Show custom language label for default language

### DIFF
--- a/Classes/Controller/ModFuncController.php
+++ b/Classes/Controller/ModFuncController.php
@@ -67,7 +67,8 @@ class ModFuncController extends AbstractFunctionModule
         $languages = [];
         $languageRecords = $this->getDatabaseConnection()->exec_SELECTgetRows('uid,title', 'sys_language', 'hidden=0', '', 'title');
         if (is_array($languageRecords) && !empty($languageRecords)) {
-            $languages[] = 'Default';
+            $defaultLanguageLabel = BackendUtility::getModTSconfig($this->pObj->id, 'mod.SHARED.defaultLanguageLabel');
+            $languages[] = $defaultLanguageLabel['value'] ?:  'Default';
             foreach ($languageRecords as $language) {
                 $languages[$language['uid']] = $language['title'];
             }


### PR DESCRIPTION
Render the value of `mod.SHARED.defaultLanguageLabel`
instead of "Default" if it's set through User/Page TSConfig.
