### PR TITLE
[BUGFIX] Set correct TYPO3 core version constraint

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -14,7 +14,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '1.1.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '7.2.0-8.9.99',
+            'typo3' => '7.6.0-8.9.99',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
as already set in composer.json
